### PR TITLE
Changes required for server skeleton generation

### DIFF
--- a/data-center-facility/facility-api.spec.yaml
+++ b/data-center-facility/facility-api.spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Facility Registry API
   version: '1.0.0'
@@ -159,14 +159,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsQuery'
+              $ref: '#/components/schemas/FacilityMetricsQuery'
       responses:
         '200':
           description: Aggregated metrics data
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsQueryResponse'
+                $ref: '#/components/schemas/FacilityMetricsQueryResponse'
         '400':
           description: Invalid query parameters
           content:
@@ -182,7 +182,7 @@ paths:
 
 components:
   schemas:
-    MetricsQuery:
+    FacilityMetricsQuery:
       type: object
       required:
         - startTime
@@ -224,7 +224,7 @@ components:
               - pue_1_ratio
               - pue_2_ratio
 
-    MetricsQueryResponse:
+    FacilityMetricsQueryResponse:
       type: object
       required:
         - facility_id
@@ -398,7 +398,7 @@ components:
           type: string
           description: Detailed description of what this metric measures
 
-    TimeSeriesDataPoint:
+    FacilityTimeSeriesDataPoint:
       type: object
       required:
         - name
@@ -447,7 +447,7 @@ components:
               type: string
               description: ISO 3166-1 alpha-3 country code
 
-    TimeSeriesConfig:
+    FacilityTimeSeriesConfig:
       type: object
       required:
         - endpoint
@@ -460,7 +460,7 @@ components:
         dataPoints:
           type: array
           items:
-            $ref: '#/components/schemas/TimeSeriesDataPoint'
+            $ref: '#/components/schemas/FacilityTimeSeriesDataPoint'
           description: List of time series metrics available for streaming
 
     FacilityResponse:
@@ -482,7 +482,7 @@ components:
               description: ISO 3166-1 alpha-3 country code derived from location
               example: NLD
             timeSeriesConfig:
-              $ref: '#/components/schemas/TimeSeriesConfig'
+              $ref: '#/components/schemas/FacilityTimeSeriesConfig'
             createdAt:
               type: string
               format: date-time
@@ -506,7 +506,7 @@ components:
           type: object
           description: Additional error details
 
-  x-supported-timeseries-metrics:
+  x-supported-facility-timeseries-metrics:
     description: List of all supported time series metrics for facility monitoring
     metrics:
       - name: heatpump_power_consumption_joules
@@ -559,7 +559,7 @@ components:
         description: Power usage effectiveness measured from the output of the PDU systems for IT load
 
 tags:
-  - name: Supported Time Series Metrics
+  - name: Supported Time Series Metrics for Facilities
     description: |
       The following metrics are supported for streaming time series data. When registering a facility, you will receive the endpoint information as well as labels for Prometheus.
       

--- a/data-center-facility/facility-api.spec.yaml
+++ b/data-center-facility/facility-api.spec.yaml
@@ -267,7 +267,7 @@ components:
                 description: Aggregated value over the time period
               unit:
                 type: string
-                enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass]
+                enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass, Value]
                 description: Unit of the metric
               granularitySeconds:
                 type: integer
@@ -392,7 +392,7 @@ components:
           description: Prometheus metric name with unit suffix
         unit:
           type: string
-          enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass]
+          enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass, Value]
           description: Prometheus metric family
         description:
           type: string
@@ -428,7 +428,7 @@ components:
             - pue_2_ratio
         unit:
           type: string
-          enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass]
+          enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass, Value]
           description: Prometheus metric family
         granularitySeconds:
           type: integer
@@ -552,10 +552,10 @@ components:
         unit: Value
         description: 1 for grid; 2 for backup generators
       - name: pue_1_ratio
-        unit: Percentage
+        unit: Percent
         description: Power usage effectiveness measured from the output of the UPS systems for IT load
       - name: pue_2_ratio
-        unit: Percentage
+        unit: Percent
         description: Power usage effectiveness measured from the output of the PDU systems for IT load
 
 tags:

--- a/rack/rack-api.spec.yaml
+++ b/rack/rack-api.spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Rack Registry API
   version: '1.0.0'
@@ -174,14 +174,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsQuery'
+              $ref: '#/components/schemas/RackMetricsQuery'
       responses:
         '200':
           description: Aggregated metrics data
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsQueryResponse'
+                $ref: '#/components/schemas/RackMetricsQueryResponse'
         '400':
           description: Invalid query parameters
           content:
@@ -236,7 +236,7 @@ components:
           required:
             - facility_id
 
-    TimeSeriesDataPoint:
+    RackTimeSeriesDataPoint:
       type: object
       required:
         - name
@@ -250,7 +250,7 @@ components:
             Prometheus metric name with unit suffix. For PDU metrics, 
             the name must follow the pattern 'pdu_N_energy_consumption_joules' 
             where N is the PDU number (1 to number_of_pdus)
-          pattern: ^(pdu_[1-9][0-9]*_energy_consumption_joules|inlet_temperature_celsius|outlet_temperature_celsius)$
+          pattern: /^(pdu_[1-9][0-9]*_energy_consumption_joules|inlet_temperature_celsius|outlet_temperature_celsius)$/
         unit:
           type: string
           enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass]
@@ -276,7 +276,7 @@ components:
               type: string
               description: ISO 3166-1 alpha-3 country code
 
-    TimeSeriesConfig:
+    RackTimeSeriesConfig:
       type: object
       required:
         - endpoint
@@ -289,7 +289,7 @@ components:
         dataPoints:
           type: array
           items:
-            $ref: '#/components/schemas/TimeSeriesDataPoint'
+            $ref: '#/components/schemas/RackTimeSeriesDataPoint'
           description: List of time series metrics available for streaming
 
     RackResponse:
@@ -306,7 +306,7 @@ components:
               description: Unique rack identifier (format RACK-[FACILITY_ID]-[RACK_ID])
               example: RACK-FACILITY-NLD-001-001
             timeSeriesConfig:
-              $ref: '#/components/schemas/TimeSeriesConfig'
+              $ref: '#/components/schemas/RackTimeSeriesConfig'
             createdAt:
               type: string
               format: date-time
@@ -314,7 +314,7 @@ components:
               type: string
               format: date-time
 
-    MetricsQuery:
+    RackMetricsQuery:
       type: object
       required:
         - startTime
@@ -340,7 +340,7 @@ components:
             type: string
             pattern: ^(pdu_[1-9][0-9]*_energy_consumption_joules|inlet_temperature_celsius|outlet_temperature_celsius)$
 
-    MetricsQueryResponse:
+    RackMetricsQueryResponse:
       type: object
       required:
         - facility_id
@@ -410,7 +410,7 @@ components:
           type: object
           description: Additional error details
 
-  x-supported-timeseries-metrics:
+  x-supported-rack-timeseries-metrics:
     description: List of all supported time series metrics for rack monitoring
     metrics:
       - name: pdu_N_energy_consumption_joules
@@ -427,7 +427,7 @@ components:
         description: Measurement of outlet cooling temperature (water or air)
 
 tags:
-  - name: Supported Time Series Metrics
+  - name: Supported Time Series Metrics for Racks
     description: |
       The following metrics are supported for streaming time series data:
       

--- a/server/server-api.spec.yaml
+++ b/server/server-api.spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Server Registry API
   version: '1.0.0'
@@ -175,14 +175,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsQuery'
+              $ref: '#/components/schemas/ServerMetricsQuery'
       responses:
         '200':
           description: Aggregated metrics data
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsQueryResponse'
+                $ref: '#/components/schemas/ServerMetricsQueryResponse'
         '400':
           description: Invalid query parameters
           content:
@@ -337,7 +337,7 @@ components:
             - rack_id
             - cooling_type
 
-    TimeSeriesDataPoint:
+    ServerTimeSeriesDataPoint:
       type: object
       required:
         - name
@@ -348,7 +348,7 @@ components:
         name:
           type: string
           description: Prometheus metric name with unit suffix
-          pattern: ^(cpu_energy_consumption_joules|server_energy_consumption_joules)$
+          pattern: /^(cpu_energy_consumption_joules|server_energy_consumption_joules)$/
         unit:
           type: string
           enum: [Time, Temperature, Length, Bytes, Percent, Voltage, "Electric current", Energy, Power, Mass]
@@ -378,7 +378,7 @@ components:
               type: string
               description: ISO 3166-1 alpha-3 country code
 
-    TimeSeriesConfig:
+    ServerTimeSeriesConfig:
       type: object
       required:
         - endpoint
@@ -391,7 +391,7 @@ components:
         dataPoints:
           type: array
           items:
-            $ref: '#/components/schemas/TimeSeriesDataPoint'
+            $ref: '#/components/schemas/ServerTimeSeriesDataPoint'
           description: List of time series metrics available for streaming
 
     ServerResponse:
@@ -407,7 +407,7 @@ components:
               description: Unique server identifier (format SERVER-[FACILITY_ID]-[RACK_ID]-[SERVER_ID])
               example: SERVER-FACILITY-NLD-001-RACK-001-001
             timeSeriesConfig:
-              $ref: '#/components/schemas/TimeSeriesConfig'
+              $ref: '#/components/schemas/ServerTimeSeriesConfig'
             createdAt:
               type: string
               format: date-time
@@ -415,7 +415,7 @@ components:
               type: string
               format: date-time
 
-    MetricsQuery:
+    ServerMetricsQuery:
       type: object
       required:
         - startTime
@@ -441,7 +441,7 @@ components:
             type: string
             pattern: ^(cpu_energy_consumption_joules|server_energy_consumption_joules)$
 
-    MetricsQueryResponse:
+    ServerMetricsQueryResponse:
       type: object
       required:
         - facility_id
@@ -515,7 +515,7 @@ components:
           type: object
           description: Additional error details
 
-  x-supported-timeseries-metrics:
+  x-supported-server-timeseries-metrics:
     description: List of all supported time series metrics for server monitoring
     metrics:
       - name: cpu_energy_consumption_joules
@@ -526,7 +526,7 @@ components:
         description: Total energy consumption of the server measured via IPMI
 
 tags:
-  - name: Supported Time Series Metrics
+  - name: Supported Time Series Metrics for Servers
     description: |
       The following metrics are supported for streaming time series data:
       


### PR DESCRIPTION
To generate Python/Flask code from this specification, a couple of changes are required:

- the version must be 3.0.0 because connexion does not support 3.1.0
- there are a few type names that are used in all APIs, but sometimes with different definitions (MetricsQuery,
  MetricsQueryResponse, TimeSeriesDataPoint, TimeSeriesConfig, x-supported-timeseries-metrics). These were renamed
  to make them unique. The only one which is used across all APIs is TimeSeriesConfig. I made a follow-up
  ticket for myself to factor this out into a separate file one day.
- the global description tag must have a unique name in each API
- Perl REs must be enclosed in //
